### PR TITLE
fix: build error with 'publicPath'

### DIFF
--- a/config/config.ts
+++ b/config/config.ts
@@ -3,7 +3,7 @@ const isCordova = false;
 const outputPath = isCordova ? 'www' : 'dist';
 const env = process.env.NODE_ENV;
 // 这里需要对应服务器地址
-const path = env === 'development' ? 'http://127.0.0.1:8000/' : outputPath;
+const path = env === 'development' ? 'http://127.0.0.1:8000/' : `${outputPath}/`;
 
 export default {
   appType: isCordova ? 'cordova' : 'h5',


### PR DESCRIPTION
```bash
$ alita build
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
Validate config "publicPath" failed, config.publicPath must end with /.
Error: config.publicPath must end with /.
```